### PR TITLE
Update README.md, publishable key

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,11 @@ Adds support for Stripe.js v3 to Nuxt.
 First run `npm i --save stripe-nuxt` and then add `stripe-nuxt` to the modules of your nuxt config. For Typescript support, also add it to the types of your tsconfig.json.
 ## Usage
 This library will expose a `$stripe` property on the Vue instance
+
+Supply your publishableKey value in `nuxt.config.js` 'modules' section:
+
+```
+modules: [
+    ['stripe-nuxt', YOUR_STRIPE_PUBLISHABLE_KEY],
+  ],
+```


### PR DESCRIPTION
Add an example to show how a stripe publishable key may be supplied in `nuxt.config.js` modules config. See #2 